### PR TITLE
setup.py: relax dependences

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
 	install_requires=[
 		'asn1crypto',
 		'winsspi>=0.0.9;platform_system=="Windows"',
-		'minikerberos==0.2.1',
+		'minikerberos>=0.2.1',
 		'aiocmd',
 		'asciitree',
 		'asysocks',


### PR DESCRIPTION
Do not use == and do not require a specific version if it's not required.