### PR TITLE
Global catalog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Detailed explanation with examples:
 	<protocol> sets the ldap protocol following values supported:
 		- ldap
 		- ldaps
+		- gc
+		- gc_ssl
 		
 	<auth> can be omitted if plaintext authentication is to be performed (in that case it default to ntlm-password), otherwise:
 		- ntlm-password

--- a/msldap/commons/url.py
+++ b/msldap/commons/url.py
@@ -231,6 +231,12 @@ class MSLDAPURLDecoder:
 		elif schemes[0] == 'LDAP_UDP':
 			self.ldap_scheme = LDAPProtocol.UDP
 			self.ldap_port = 389
+		elif schemes[0] == 'GC':
+			self.ldap_scheme = LDAPProtocol.TCP
+			self.ldap_port = 3268
+		elif schemes[0] == 'GC_SSL':
+			self.ldap_scheme = LDAPProtocol.SSL
+			self.ldap_port = 3269
 		else:
 			raise Exception('Unknown protocol! %s' % schemes[0])
 		


### PR DESCRIPTION
quick change to add support to authenticate to the global catalog of a DC (and also mention it in the readme, but feel free to remove that as some of the built-in queries to the example client don't work super well as the partial attribute set doesn't include the attributes they are looking for)