### PR TITLE
Add a check to ParserActions.return_escaped_char

### DIFF
--- a/msldap/protocol/ldap_filter/filter.py
+++ b/msldap/protocol/ldap_filter/filter.py
@@ -409,7 +409,7 @@ class ParserActions:
     def return_escaped_char(self, input, start, end, elements=None):
         string = self.elements_to_string(elements)
 
-        if string:
+        if string and string != '\\':
             chr_code = int(string.replace('\\', ''))
 
             return chr(chr_code)


### PR DESCRIPTION
Hi,

I faced an exception in `ParserActions.return_escaped_char()` function when an element text value is equal to `\\` (0x5C).
I just added a check to the function to handle this case.