### PR TITLE
Fix ldap search with binary values

### DIFF
--- a/msldap/protocol/ldap_filter/parser.py
+++ b/msldap/protocol/ldap_filter/parser.py
@@ -1266,16 +1266,16 @@ class Grammar(object):
         chunk0 = None
         if self._offset < self._input_size:
             chunk0 = self._input[self._offset:self._offset + 1]
-        if chunk0 == '\\':
-            address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
-            self._offset = self._offset + 1
-        else:
-            address1 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append('\'\\\\\'')
+        #if chunk0 == '\\':
+        #    address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+        #    self._offset = self._offset + 1
+        #else:
+        address1 = FAILURE
+        if self._offset > self._failure:
+            self._failure = self._offset
+            self._expected = []
+        if self._offset == self._failure:
+            self._expected.append('\'\\\\\'')
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = self._read_ASCII_VALUE()


### PR DESCRIPTION
`\\XX` (`XX` being an hex value) in ldap query string value was re-decoded in the query string using `chr(\xXX)` by calling `_read_EscapedCharacter -> _read_ASCII_VALUE -> _read_HEX_VALUE`. 

However `chr()` interprets `\xXX` as a unicode code point U+00XX but for example U+00a0 has a binary representation of `\xC2\xA0`. Hence, the current parser doesn't correctly handle the encoding of the `\\XX` bytes provided by the user and the binary search cannot be used because it sends a wrong binary representation to the server.

To comply with RFC 4515 specifying that the notation `\\XX` can be used to search for binary values, I disabled the re-encoding part detected by `if chunk0 == '\\'` l.1263 in msldap/protocol/ldap_filter/parser.py and instead called a special encoding function called `RFC4515_encode()` when encoding the string into the asn1 structure. The encoding function cannot be called before (e.g. instead of _read_HEX_VALUE) because not all bytes have a string representation in UTF8 and for example `b'\xa0'.decode()` will fail and as stated previously chr(\xa0) will not give the right decoding of our binary value.

With this PR, you'll be able to perform queries such as this one:
```
guid_str = "\\" + "\\".join([
                "{:02x}".format(b)
                for b in dtyp.guid.GUID().from_string('2628A46A-A6AD-4AE0-B854-2B12D9FE6F9E').to_bytes()
            ])
    filter = f"(schemaIDGUID={guid_str})"
connection.pagedsearch(query= f"(schemaIDGUID={guid_str})", attributes=attributes, tree=dn)
```
'2628A46A-A6AD-4AE0-B854-2B12D9FE6F9E' being the schemaIDGUID for CN=account,CN=Schema,CN=Configuration,DC=your,DC=domain