### PR TITLE
Fix broken single int encoding

### DIFF
--- a/msldap/protocol/typeconversion.py
+++ b/msldap/protocol/typeconversion.py
@@ -94,7 +94,7 @@ def single_bytes(x, encode = False):
 def single_int(x, encode = False):
 	if encode is False:
 		return int(x[0])
-	return [str(x).encode()]
+	return [str(x[0]).encode()]
 
 def single_bool(x, encode = False, encoding = 'utf-8'):
 	if encode is False:


### PR DESCRIPTION
Currently single int encoding encodes the entire list with square brackets like so: b'[1234]' when it should be encoding as b'1234' and thus causes a invalidAttributeSyntax ldap error.

The fix is to replace str(x).encode() with str(x[0]).encode() 

Other attribute types might be affected by the same bug, haven't checked. 