### PR TITLE
feature: dnsproperty parsing for dnszones command

### DIFF
--- a/msldap/commons/utils.py
+++ b/msldap/commons/utils.py
@@ -1,109 +1,124 @@
-
 import datetime
-import time
-import calendar
+from ipaddress import IPv4Address, IPv6Address
+from typing import Union
 
-def timestamp2datetime(dt) -> datetime.datetime:
-	"""
-	Converting Windows timestamps to datetime.datetime format
-	:param dt: Windows timestamp as array of bytes
-	:type dt: bytearray
-	:return: datetime.datetime
-	"""
-	us = int.from_bytes(dt, byteorder='little')/ 10.
-	return datetime.datetime(1601, 1, 1) + datetime.timedelta(microseconds=us)
-	
-	
+
+def timestamp2datetime(dt: Union[bytes, int]) -> datetime.datetime:
+    """
+    Converting Windows timestamps to datetime.datetime format
+    :param dt: Windows timestamp as array of bytes or integer
+    :type dt: bytearray | int
+    :return: datetime.datetime
+    """
+
+    if isinstance(dt, bytes):
+        dt = int.from_bytes(dt, "little")
+
+    return datetime.datetime(1601, 1, 1) + datetime.timedelta(microseconds=dt / 10)
+
+
 def datetime2timestamp(dt) -> int:
-	delta = dt - datetime.datetime(1601, 1, 1)
-	ns = int((delta / datetime.timedelta(microseconds=1)) * 10)
-	return ns.to_bytes(8, 'little', signed = False)
+    delta = dt - datetime.datetime(1601, 1, 1)
+    ns = int((delta / datetime.timedelta(microseconds=1)) * 10)
+    return ns.to_bytes(8, "little", signed=False)
+
+
+def bytes2ipv4(data: bytes) -> str:
+    return str(IPv4Address(data))
+
+
+def bytes2ipv6(data: bytes) -> str:
+    return str(IPv6Address(data))
+
 
 def wrap(s, w) -> str:
-	return [s[i:i + w] for i in range(0, len(s), w)]
+    return [s[i : i + w] for i in range(0, len(s), w)]
+
 
 def print_cert(cert, offset=0) -> str:
-	cert = cert['tbs_certificate']
-	blanks = " " * offset
-	msg = [
-			"Cert Subject: %s" % cert['subject']['common_name'],
-			"Cert Serial: %s" % cert['serial_number'],
-			"Cert Start: %s" % cert['validity']['not_before'],
-			"Cert End: %s" % cert['validity']['not_after'],
-			"Cert Issuer: %s" % cert['issuer']['common_name'],
-		]
-	return "{}{}".format(blanks, "\n{}".format(blanks).join(msg))
+    cert = cert["tbs_certificate"]
+    blanks = " " * offset
+    msg = [
+        "Cert Subject: %s" % cert["subject"]["common_name"],
+        "Cert Serial: %s" % cert["serial_number"],
+        "Cert Start: %s" % cert["validity"]["not_before"],
+        "Cert End: %s" % cert["validity"]["not_after"],
+        "Cert Issuer: %s" % cert["issuer"]["common_name"],
+    ]
+    return "{}{}".format(blanks, "\n{}".format(blanks).join(msg))
+
 
 def win_timestamp_to_unix(seconds):
-	"""
-	Convert Windows timestamp (100 ns since 1 Jan 1601) to
-	unix timestamp.
-	"""
-	seconds = int(seconds)
-	if seconds == 0:
-		return 0
-	return int((seconds - 116444736000000000) / 10000000)
+    """
+    Convert Windows timestamp (100 ns since 1 Jan 1601) to
+    unix timestamp.
+    """
+    seconds = int(seconds)
+    if seconds == 0:
+        return 0
+    return int((seconds - 116444736000000000) / 10000000)
 
-def bh_dt_convert(dt:datetime.datetime):
-	if dt is None or dt == 0 or dt == '0' or dt == '':
-		return -1
-	ts = max(0,int(dt.timestamp()))
-	return ts
+
+def bh_dt_convert(dt: datetime.datetime):
+    if dt is None or dt == 0 or dt == "0" or dt == "":
+        return -1
+    ts = max(0, int(dt.timestamp()))
+    return ts
 
 
 FUNCTIONAL_LEVELS = {
-		0: "2000 Mixed/Native",
-		1: "2003 Interim",
-		2: "2003",
-		3: "2008",
-		4: "2008 R2",
-		5: "2012",
-		6: "2012 R2",
-		7: "2016"
-	}
+    0: "2000 Mixed/Native",
+    1: "2003 Interim",
+    2: "2003",
+    3: "2008",
+    4: "2008 R2",
+    5: "2012",
+    6: "2012 R2",
+    7: "2016",
+}
 
 KNOWN_SIDS = {
-	"S-1-0": "Null Authority",
-	"S-1-0-0": "Nobody",
-	"S-1-1": "World Authority",
-	"S-1-1-0": "Everyone",
-	"S-1-2": "Local Authority",
-	"S-1-2-0": "Local",
-	"S-1-3": "Creator Authority",
-	"S-1-3-0": "Creator Owner",
-	"S-1-3-1": "Creator Group",
-	"S-1-3-4": "Owner Rights",
-	"S-1-4": "Non-unique Authority",
-	"S-1-5": "NT Authority",
-	"S-1-5-1": "Dialup",
-	"S-1-5-2": "Network",
-	"S-1-5-3": "Batch",
-	"S-1-5-4": "Interactive",
-	"S-1-5-5-X-Y": "Logon Session",
-	"S-1-5-6": "Service",
-	"S-1-5-7": "Anonymous",
-	"S-1-5-9": "Enterprise Domain Controllers",
-	"S-1-5-10": "Principal Self",
-	"S-1-5-11": "Authenticated Users",
-	"S-1-5-12": "Restricted Code",
-	"S-1-5-13": "Terminal Server Users",
-	"S-1-5-14": "Remote Interactive Logon",
-	"S-1-5-17": "IUSR",
-	"S-1-5-18": "Local System",
-	"S-1-5-19": "NT Authority Local Service",
-	"S-1-5-20": "NT Authority Network Service",
-	"S-1-5-32-544": "Administrators",
-	"S-1-5-32-545": "Users",
-	"S-1-5-32-546": "Guests",
-	"S-1-5-32-547": "Power Users",
-	"S-1-5-32-548": "Account Operators",
-	"S-1-5-32-549": "Server Operators",
-	"S-1-5-32-550": "Print Operators",
-	"S-1-5-32-551": "Backup Operators",
-	"S-1-5-32-552": "Replicators",
-	"S-1-5-32-582": "Storage Replica Administrators",
-	"S-1-5-64-10": "NTLM Authentication",
-	"S-1-5-64-14": "SChannel Authentication",
-	"S-1-5-64-21": "Digest Authentication",
-	"S-1-5-80": "NT Service",
+    "S-1-0": "Null Authority",
+    "S-1-0-0": "Nobody",
+    "S-1-1": "World Authority",
+    "S-1-1-0": "Everyone",
+    "S-1-2": "Local Authority",
+    "S-1-2-0": "Local",
+    "S-1-3": "Creator Authority",
+    "S-1-3-0": "Creator Owner",
+    "S-1-3-1": "Creator Group",
+    "S-1-3-4": "Owner Rights",
+    "S-1-4": "Non-unique Authority",
+    "S-1-5": "NT Authority",
+    "S-1-5-1": "Dialup",
+    "S-1-5-2": "Network",
+    "S-1-5-3": "Batch",
+    "S-1-5-4": "Interactive",
+    "S-1-5-5-X-Y": "Logon Session",
+    "S-1-5-6": "Service",
+    "S-1-5-7": "Anonymous",
+    "S-1-5-9": "Enterprise Domain Controllers",
+    "S-1-5-10": "Principal Self",
+    "S-1-5-11": "Authenticated Users",
+    "S-1-5-12": "Restricted Code",
+    "S-1-5-13": "Terminal Server Users",
+    "S-1-5-14": "Remote Interactive Logon",
+    "S-1-5-17": "IUSR",
+    "S-1-5-18": "Local System",
+    "S-1-5-19": "NT Authority Local Service",
+    "S-1-5-20": "NT Authority Network Service",
+    "S-1-5-32-544": "Administrators",
+    "S-1-5-32-545": "Users",
+    "S-1-5-32-546": "Guests",
+    "S-1-5-32-547": "Power Users",
+    "S-1-5-32-548": "Account Operators",
+    "S-1-5-32-549": "Server Operators",
+    "S-1-5-32-550": "Print Operators",
+    "S-1-5-32-551": "Backup Operators",
+    "S-1-5-32-552": "Replicators",
+    "S-1-5-32-582": "Storage Replica Administrators",
+    "S-1-5-64-10": "NTLM Authentication",
+    "S-1-5-64-14": "SChannel Authentication",
+    "S-1-5-64-21": "Digest Authentication",
+    "S-1-5-80": "NT Service",
 }

--- a/msldap/examples/msldapclient.py
+++ b/msldap/examples/msldapclient.py
@@ -5,49 +5,47 @@
 #
 
 import asyncio
-import traceback
-import logging
-import shlex
-import datetime
 import copy
-import typing
-import json
-import base64
-import zipfile
-import os
+import datetime
 import importlib.util
+import json
+import logging
+import os
+import shlex
 import sys
+import traceback
+import typing
+import zipfile
 
-from asysocks.unicomm.common.target import UniTarget
+from asyauth import logger as authlogger
 from asyauth.common.credentials import UniCredential
-from msldap.external.aiocmd.aiocmd import aiocmd
-from msldap.external.asciitree.asciitree import LeftAligned
+from asysocks import logger as sockslogger
+from asysocks.unicomm.common.target import UniTarget
+from tabulate import tabulate
 from tqdm import tqdm
+from winacl.dtyp.ace import (ACCESS_ALLOWED_ACE, ACCESS_ALLOWED_OBJECT_ACE,
+                             ACE_OBJECT_PRESENCE, ADS_ACCESS_MASK, AceFlags,
+                             ACEType)
+from winacl.dtyp.acl import ACL
+from winacl.dtyp.guid import GUID
+from winacl.dtyp.security_descriptor import SE_SACL, SECURITY_DESCRIPTOR
+from winacl.dtyp.sid import SID
 
 from msldap import logger
-from asysocks import logger as sockslogger
-from asyauth import logger as authlogger
-from msldap.client import MSLDAPClient
 from msldap.commons.factory import LDAPConnectionFactory
-from msldap.ldap_objects import MSADUser, MSADMachine, MSADUser_TSV_ATTRS, \
-	MSADMachine_ATTRS, MSADGroup_ATTRS, MSADOU_ATTRS, MSADInfo_ATTRS, \
-	MSADContainer_ATTRS, MSADGPO_ATTRS, MSADDomainTrust_ATTRS
-
-from msldap.examples.utils.completers import PathCompleter
-
-from winacl.dtyp.security_descriptor import SECURITY_DESCRIPTOR, SE_SACL
-from winacl.dtyp.ace import ACCESS_ALLOWED_OBJECT_ACE, ADS_ACCESS_MASK, AceFlags,\
-	ACE_OBJECT_PRESENCE, ACEType, ACCESS_ALLOWED_ACE, ACCESS_DENIED_ACE
-from winacl.dtyp.sid import SID
-from winacl.dtyp.guid import GUID
-from winacl.dtyp.acl import ACL
-
-from msldap.ldap_objects.adcertificatetemplate import MSADCertificateTemplate,\
-	EX_RIGHT_CERTIFICATE_ENROLLMENT, CertificateNameFlag
-from msldap.wintypes.asn1.sdflagsrequest import SDFlagsRequest
-from tabulate import tabulate
-from msldap.commons.exceptions import LDAPSearchException
 from msldap.commons.plugin import MSLDAPConsolePlugin
+from msldap.examples.utils.completers import PathCompleter
+from msldap.external.aiocmd.aiocmd import aiocmd
+from msldap.external.asciitree.asciitree import LeftAligned
+from msldap.ldap_objects import (MSADGPO_ATTRS, MSADOU_ATTRS,
+                                 MSADContainer_ATTRS, MSADDomainTrust_ATTRS,
+                                 MSADGroup_ATTRS, MSADInfo_ATTRS,
+                                 MSADMachine_ATTRS, MSADUser_TSV_ATTRS)
+from msldap.ldap_objects.adcertificatetemplate import (
+    EX_RIGHT_CERTIFICATE_ENROLLMENT, CertificateNameFlag,
+    MSADCertificateTemplate)
+from msldap.wintypes.asn1.sdflagsrequest import SDFlagsRequest
+
 
 class MSLDAPClientConsole(aiocmd.PromptToolkitCmd):
 	def __init__(self, url = None):
@@ -1521,13 +1519,22 @@ class MSLDAPClientConsole(aiocmd.PromptToolkitCmd):
 			traceback.print_exc()
 	"""
 
-	async def do_dnszones(self):
+	async def do_dnszones(self, to_print_props = False):
 		"""Lists all DNS zones"""
 		try:
-			async for entry, err in self.connection.dnslistzones():
+			async for entry, props, err in self.connection.dnslistzones():
 				if err is not None:
 					raise err
+
 				print(entry)
+
+				if to_print_props is False:
+					continue
+
+				for prop in props:
+					print(" ", prop)
+
+				print()
 
 			return True
 		except:
@@ -1605,8 +1612,9 @@ async def amain(args):
 		if platform.system() != 'Windows':
 			raise Exception('This function only works on Windows systems!')
 		from asyauth.common.credentials import UniCredential
-		from msldap.commons.target import MSLDAPTarget, UniProto
 		from winacl.functions.highlevel import get_logon_info
+
+		from msldap.commons.target import MSLDAPTarget, UniProto
 		cred = UniCredential.get_sspi(args.authtype)
 		userinfo = get_logon_info()
 		if args.target is not None:

--- a/msldap/wintypes/dnsp/structures/__init__.py
+++ b/msldap/wintypes/dnsp/structures/__init__.py
@@ -1,0 +1,3 @@
+from .dnsproperty import *
+from .dnsrecord import *
+from .misc import *

--- a/msldap/wintypes/dnsp/structures/dnsproperty.py
+++ b/msldap/wintypes/dnsp/structures/dnsproperty.py
@@ -1,0 +1,284 @@
+# NOTE: implementation is based on https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/445c7843-e4a1-4222-8c0f-630c230a4c80
+
+from __future__ import annotations
+
+import sys
+from typing import ClassVar, Generic, List, Optional, TypeVar
+
+from msldap.commons.utils import timestamp2datetime
+from msldap.wintypes.dnsp.structures.misc import DnsAddrArray, Ip4Array
+
+# NOTE: typing.Type is deprecated since version 3.9
+if sys.version_info < (3, 9):
+    from typing import Type
+else:
+    Type = type
+
+
+# NOTE: to make typing happy with auto-implementation of from_bytes
+class _Unserializable:
+    @classmethod
+    def from_bytes(cls, data: bytes, byteorder: str) -> _Unserializable:
+        ...
+
+
+# NOTE: by default, consider BaseType unserializable to make possible the generation of from_bytes method
+BaseType = TypeVar("BaseType", bound=_Unserializable)
+
+
+class BaseDnsProperty(Generic[BaseType]):
+    _id: ClassVar[int] = None
+    _name: ClassVar[str] = None
+
+    _base_type: ClassVar[Type[BaseType]] = None
+    _default: ClassVar[BaseType] = None
+
+    _implementations: ClassVar[List[Type[BaseDnsProperty]]] = []
+
+    def __init__(self, value: Optional[BaseType] = None) -> None:
+        self._value = value if value is not None else self._default
+
+    def __str__(self) -> str:
+        return f"{self._name}: {self.value}"
+
+    @property
+    def value(self) -> str:
+        return str(self._value)
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> BaseDnsProperty:
+        return cls(cls._base_type.from_bytes(data, "little"))
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+
+        cls._base_type = cls.__orig_bases__[0].__args__[0]
+
+        if (cls._id is not None) and (cls._name is not None):
+            cls._implementations.append(cls)
+
+
+class DnsEnumProperty(BaseDnsProperty[int]):
+    _types: ClassVar[dict[int, str]] = None
+
+    @property
+    def value(self) -> str:
+        return self._types.get(self._value, "Unknown")
+
+
+class DnsFlagsProperty(BaseDnsProperty[int]):
+    _flags: ClassVar[dict[int, str]] = None
+
+    @property
+    def value(self) -> str:
+        return " | ".join(
+            value for (key, value) in self._flags.items() if (self._value & key)
+        )
+
+
+class DnsHoursIntervalProperty(BaseDnsProperty[int]):
+    @property
+    def value(self) -> str:
+        if self._value == 0:
+            return "0 hours"
+
+        result = ""
+
+        days = self._value // 24
+        if days != 0:
+            result += f"{days} days "
+
+        hours = self._value % 24
+        if hours != 0:
+            result += f"{hours} hours "
+
+        return result.rstrip()
+
+
+class DnsTimestampProperty(BaseDnsProperty[int]):
+    @property
+    def value(self) -> str:
+        if self._value == 0:
+            return "Never"
+
+        return timestamp2datetime(self._value).isoformat()
+
+
+class DnsNullTerminatedStringProperty(BaseDnsProperty[str]):
+    @classmethod
+    def from_bytes(cls, data: bytes) -> DnsNullTerminatedStringProperty:
+        return cls(data.decode("utf-8").rstrip("\x00"))
+
+
+# NOTE: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/27e138a7-110c-44a4-afcb-b95f35f00306
+class DnsZoneType(DnsEnumProperty):
+    _id = 0x01
+    _name = "Zone Type"
+
+    _default = 1
+
+    _types = {
+        0: "Cache",
+        1: "Primary",
+        2: "Secondary",
+        3: "Stub",
+        4: "Forwarder",
+        5: "Secondary Cache",
+    }
+
+
+# NOTE: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/d4b84209-f00c-478f-80d7-8dd0f1633d9e
+class DnsZoneAllowUpdate(DnsEnumProperty):
+    _id = 0x02
+    _name = "Dynamic Updates"
+
+    _default = -1
+
+    _types = {
+        0: "Not allowed",
+        1: "All updates allowed",
+        2: "Only secure updates allowed",
+    }
+
+
+class DnsZoneSecureTime(DnsTimestampProperty):
+    _id = 0x08
+    _name = "Time Zone Secured"
+
+    _default = 0
+
+
+class DnsZoneNoRefreshInterval(DnsHoursIntervalProperty):
+    _id = 0x10
+    _name = "Zone No-Refresh Interval"
+
+    _default = 168
+
+
+class DnsZoneRefreshInterval(DnsHoursIntervalProperty):
+    _id = 0x20
+    _name = "Zone Refresh Interval"
+
+    _default = 168
+
+
+class DnsZoneAgingState(BaseDnsProperty[bool]):
+    _id = 0x40
+    _name = "Aging Enabled"
+
+    _default = False
+
+
+class DnsZoneScavengingServers(BaseDnsProperty[Ip4Array]):
+    _id = 0x11
+    _name = "DNS Servers performing Scavenging"
+
+    _default = Ip4Array()
+
+
+class DnsZoneAgingEnabledTime(DnsHoursIntervalProperty):
+    _id = 0x12
+    _name = "Time before the next Scavenging Cycle"
+
+    _default = 0
+
+
+class DnsZoneDeletedFromHostname(DnsNullTerminatedStringProperty):
+    _id = 0x80
+    _name = "Name of Server that deleted the Zone"
+
+    _default = "Unknown"
+
+
+class DnsZoneMasterServers(BaseDnsProperty[Ip4Array]):
+    _id = 0x81
+    _name = "DNS Servers performing Zone Transfers"
+
+    _default = Ip4Array()
+
+
+class DnsZoneAutoNsServers(BaseDnsProperty[Ip4Array]):
+    _id = 0x82
+    _name = "DNS Servers which may autocreate a Delegation"
+
+    _default = Ip4Array()
+
+
+# NOTE: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/4ec7bdf7-1807-4179-96af-ce1c1cd448b7
+class DnsZoneDcPromoConvert(DnsEnumProperty):
+    _id = 0x83
+    _name = "State of Conversion"
+
+    _default = 0
+
+    _types = {
+        0: "None",
+        1: "To be moved to DNS Domain partition",
+        2: "To be moved to DNS Forest partition",
+    }
+
+
+class DnsZoneScavengingServersDa(BaseDnsProperty[DnsAddrArray]):
+    _id = 0x90
+    _name = "DNS Servers performing Scavenging"
+
+    _default = DnsAddrArray()
+
+
+class DnsZoneMasterServersDa(BaseDnsProperty[DnsAddrArray]):
+    _id = 0x91
+    _name = "DNS Servers performing Zone Transfers"
+
+    _default = DnsAddrArray()
+
+
+class DnsZoneAutoNsServersDa(BaseDnsProperty[DnsAddrArray]):
+    _id = 0x92
+    _name = "DNS Servers which may autocreate a Delegation"
+
+    _default = DnsAddrArray()
+
+
+# NOTE: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/f448341f-512d-414a-aaa3-e303d592fcd2
+class DnsZoneNodeDbFlags(DnsFlagsProperty):
+    _id = 0x100
+    _name = "DB Flags"
+
+    _default = 0
+
+    _flags = {
+        0x80000000: "DNS_RPC_FLAG_CACHE_DATA",
+        0x40000000: "DNS_RPC_FLAG_ZONE_ROOT",
+        0x20000000: "DNS_RPC_FLAG_AUTH_ZONE_ROOT",
+        0x10000000: "DNS_RPC_FLAG_ZONE_DELEGATION",
+        0x08000000: "DNS_RPC_FLAG_RECORD_DEFAULT_TTL",
+        0x04000000: "DNS_RPC_FLAG_RECORD_TTL_CHANGE",
+        0x02000000: "DNS_RPC_FLAG_RECORD_CREATE_PTR",
+        0x01000000: "DNS_RPC_FLAG_NODE_STICKY",
+        0x00800000: "DNS_RPC_FLAG_NODE_COMPLETE",
+        0x00010000: "DNS_RPC_FLAG_SUPPRESS_NOTIFY",
+        0x00020000: "DNS_RPC_FLAG_AGING_ON",
+        0x00040000: "DNS_RPC_FLAG_OPEN_ACL",
+        0x00100000: "DNS_RPC_FLAG_RECORD_WIRE_FORMAT",
+        0x00200000: "DNS_RPC_FLAG_SUPPRESS_RECORD_UPDATE_PTR",
+    }
+
+
+class DnsPropertyFactory:
+    def __init__(self) -> None:
+        self._factories = {
+            subclass._id: subclass for subclass in BaseDnsProperty._implementations
+        }
+
+    def from_bytes(self, data: bytes) -> Optional[BaseDnsProperty]:
+        length = int.from_bytes(data[:4], "little")
+        id = int.from_bytes(data[16:20], "little")
+
+        FactoryClass = self._factories.get(id)
+        if FactoryClass is None:
+            return None
+
+        if length == 0:
+            return FactoryClass()
+
+        return FactoryClass.from_bytes(data[20 : 20 + length])

--- a/msldap/wintypes/dnsp/structures/dnsrecord.py
+++ b/msldap/wintypes/dnsp/structures/dnsrecord.py
@@ -1,9 +1,12 @@
-
 # parts of the dns implementation was taken from https://github.com/dirkjanm/adidnsdump
+
+import datetime
 import enum
 import io
-import datetime
 from typing import List
+
+from msldap.commons.utils import bytes2ipv4, bytes2ipv6
+
 
 class DNS_RECORD_TYPE(enum.Enum):
 	ZERO = 0x0000 #An empty record type ([RFC1034] section 3.6 and [RFC1035] section 3.2.2).
@@ -140,8 +143,7 @@ class DNS_RPC_RECORD_A:
 		ipv4_bytes = buff.read(4)
 		
 		# Convert each byte to an integer and join them with dots to form the IPv4 address
-		ipv4_str = '.'.join(str(byte) for byte in ipv4_bytes)
-		res.IpAddress = ipv4_str
+		res.IpAddress = bytes2ipv4(ipv4_bytes)
 		
 		return res
 	
@@ -165,11 +167,9 @@ class DNS_RPC_RECORD_AAAA:
 		# webassembly pyodide has problems with socket implementation
 		#res.IpAddress = socket.inet_ntop(socket.AF_INET6, buff.read(16))
 		ipv6_bytes = buff.read(16)
-		ipv6_hex = ''.join(f'{byte:02x}' for byte in ipv6_bytes)
-		
+
 		# Convert the hex string into the standard IPv6 format
-		ipv6_str = ":".join(ipv6_hex[i:i + 4] for i in range(0, 32, 4))
-		res.IpAddress = ipv6_str
+		res.IpAddress = bytes2ipv6(ipv6_bytes)
 		return res
 	
 	def to_line(self, separator = '\t'):

--- a/msldap/wintypes/dnsp/structures/misc.py
+++ b/msldap/wintypes/dnsp/structures/misc.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from msldap.commons.utils import bytes2ipv4, bytes2ipv6
+
+
+# NOTE: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/588ae296-71bf-402f-9996-86ecee39dc29
+class Ip4Array:
+    def __init__(self, servers: List[str] = []) -> Ip4Array:
+        self._servers = servers.copy()
+
+    @classmethod
+    def from_bytes(cls, data: bytes, _: Optional[str] = None) -> Ip4Array:
+        num_ips = int.from_bytes(data[:4], "little")
+
+        ips = [bytes2ipv4(data[i * 4 + 4 : i * 4 + 8]) for i in range(num_ips)]
+
+        return Ip4Array(ips)
+
+    def __str__(self) -> str:
+        if self._servers == []:
+            return "None"
+
+        return ", ".join(self._servers)
+
+
+# NOTE: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/56ba5fab-f304-4866-99a4-4f1c1f9247a3
+class DnsAddrArray:
+    AF_IPV4 = 0x0002
+    AF_IPV6 = 0x0017
+
+    def __init__(self, servers: List[str] = []) -> DnsAddrArray:
+        self._servers = servers.copy()
+
+    @classmethod
+    def from_bytes(cls, data: bytes, _: Optional[str] = None) -> DnsAddrArray:
+        num_addrs = int.from_bytes(data[:4], "little")
+
+        servers = list()
+
+        for i in range(num_addrs):
+            raw_addr = data[32 + i * 64 : 32 + (i + 1) * 64]
+
+            family = int.from_bytes(raw_addr[:2], "little")
+            if family == cls.AF_IPV4:
+                ip = bytes2ipv4(raw_addr[4:8])
+            elif family == cls.AF_IPV6:
+                ip = bytes2ipv6(raw_addr[8:24])
+            else:
+                ip = "Unknown"
+
+            port = int.from_bytes(raw_addr[2:4], "big")
+
+            servers.append(f"{ip}:{port}")
+
+        return DnsAddrArray(servers)
+
+    def __str__(self) -> str:
+        if self._servers == []:
+            return "None"
+
+        return ", ".join(self._servers)


### PR DESCRIPTION
The `dnszones` and `dnsdump` commands are implemented incorrectly in the current version of `msldap`:

1. The `dnszones` command does not properly look for `dnsZone` objects, as it uses the wrong Base DN (the `tree` parameter of the `pagedsearch` method). As a result, actual DNS zones are not printed at all.
2. The `dnsdump` command does not look for records in `DC=ForestDnsZones,DC=domain,DC=local` catalog. As a result, not all DNS records stored in ADIDNS are dumped.

![Incorrect implementation of dnszones and dnsdump](https://github.com/user-attachments/assets/e5cdc20c-3c39-43e8-891d-1920b9b33011)

Moreover, there is a lack of functionality for parsing the `dNSProperty` property of `dnsZone` objects. This property may contain information useful for real engagements. For instance, this property is used when a Conditional Forwarder is created, which allows for forwarding DNS requests to external servers for specific DNS zones.

This pull request introduces the following main changes:

1. The implementations of the `dnszones` and `dnsdump` commands have been fixed.
2. A new parameter allowing for printing the properties of DNS zones has been introduced for the `dnszones` command.

![Correct implementation of dnszones and dnsdump](https://github.com/user-attachments/assets/a7c62552-81c5-4809-9895-2edb54e70639)

![Example of priting the zone properties](https://github.com/user-attachments/assets/f6e16621-ccb4-4a91-a457-46b6b3a0e384)

Other minor changes are related to using the `isort` and `black` tools to format the code. `black` is not used for `client.py` and `msldapclient.py` files to avoid creating too many changes in the commit.
