### PR TITLE
Option to send raw values

### DIFF
--- a/msldap/client.py
+++ b/msldap/client.py
@@ -1154,7 +1154,7 @@ class MSLDAPClient:
 			elif 'group' in temp:
 				yield MSADGroup.from_ldap(entry), None
 
-	async def modify(self, dn:str, changes:Dict[str, object], controls:Dict[str, object] = None):
+	async def modify(self, dn:str, changes:Dict[str, object], controls:Dict[str, object] = None, encode=True):
 		"""
 		Performs the modify operation.
 		
@@ -1164,6 +1164,9 @@ class MSLDAPClient:
 		:type changes: dict
 		:param controls: additional controls to be passed in the query
 		:type controls: dict
+		:param encode: encode the changes provided before sending them to the server
+    	:type encode: bool
+		
 		:return: A tuple of (True, None) on success or (False, Exception) on error. 
 		:rtype: (:class:`bool`, :class:`Exception`)
 		"""
@@ -1172,7 +1175,7 @@ class MSLDAPClient:
 		controls_conv = []
 		for control in controls:	
 			controls_conv.append(Control(control))
-		return await self._con.modify(dn, changes, controls=controls_conv)
+		return await self._con.modify(dn, changes, controls=controls_conv, encode=encode)
 
 
 	async def add(self, dn:str, attributes:Dict[str, object]):

--- a/msldap/connection.py
+++ b/msldap/connection.py
@@ -591,7 +591,7 @@ class MSLDAPClientConnection:
 		except Exception as e:
 			return False, e
 
-	async def modify(self, entry:str, changes:Dict[str, object], controls:List[Control] = None):
+	async def modify(self, entry:str, changes:Dict[str, object], controls:List[Control] = None, encode=True,):
 		"""
 		Performs the modify operation.
 		
@@ -601,13 +601,16 @@ class MSLDAPClientConnection:
 		:type changes: dict
 		:param controls: additional controls to be passed in the query
 		:type controls: List[class:`Control`] 
+		:param encode: encode the changes provided before sending them to the server
+    	:type encode: bool
+
 		:return: A tuple of (True, None) on success or (False, Exception) on error. 
 		:rtype: (:class:`bool`, :class:`Exception`)
 		"""
 		try:
 			req = {
 				'object' : entry.encode(),
-				'changes' : encode_changes(changes)
+				'changes' : encode_changes(changes, encode)
 			}
 			br = { 'modifyRequest' : ModifyRequest(req)}
 			msg = { 'protocolOp' : protocolOp(br)}


### PR DESCRIPTION
Option to send already encoded values calling MSLDAPClient.modify. Disabled by default to not disturb tools already using this function.
I also added LDAP_WELL_KNOWN_ATTRS in the available lookup tables to increase encoding possibilities