### PR TITLE
Ability to force user to reset password + additional method

### DIFF
--- a/msldap/client.py
+++ b/msldap/client.py
@@ -444,6 +444,23 @@ class MSLDAPClient:
 					
 		logger.debug('Finished polling for entries!')
 
+	async def get_dn(self, sAMAccountName: str):
+		"""
+		Fetches the distinguished name for a samAccountName.
+
+		:param sAMAccountName: The username of the machine (eg. COMP123$).
+		:type sAMAccountName: str
+		:return: DN if found, else None; and an error if any.
+		:rtype: Tuple[Optional[str], Optional[Exception]]
+		"""
+		ldap_filter = r'(sAMAccountName=%s)' % str(sAMAccountName)
+		async for entry, err in self.pagedsearch(ldap_filter, ['distinguishedName']):
+			if err is not None:
+				return None, err
+
+			return entry['attributes']['distinguishedName'], None
+		return None, Exception('Search returned no results!')
+
 	async def get_laps(self, sAMAccountName:str):
 		"""
 		Fetches the LAPS password for a machine. This functionality is only available to specific high-privileged users.

--- a/msldap/protocol/typeconversion.py
+++ b/msldap/protocol/typeconversion.py
@@ -419,6 +419,7 @@ MSLDAP_BUILTIN_ATTRIBUTE_TYPES_ENC = {
 	"msDS-ManagedPasswordInterval" : single_int,
 	"msDS-SupportedEncryptionTypes" : single_int,
 	"msDS-GroupMSAMembership" : single_sd,
+	"pwdLastSet" : single_int,
 }
 
 def encode_attributes(x):


### PR DESCRIPTION
Hi skelsec,

I played around with msldap and tried to force a user to reset his password. What I found out is, that the single_interval method from typeconversion.py does not have implemented a condition, if encode is set to True.

So I made a workaround for this issue and set the pwdLastSet Attribute with a single_int in the MSLDAP_BUILTIN_ATTRIBUTE_TYPES_ENC list. This way, I am able to make a change to the attribute with following two params:

 0 (int) > forces the user to reset the password at next logon
-1 (int) > reverts the password change force and sets the timestamp to the actual time now

(this workflow is also used by the account option build-in "User must change password at next logon")

Another idea was to implement the missing part in the single_interval method but I am not sure, if or what else may not work correctly, if an condition for encoded=true is in place, to set integer values.

If this is an valid way for you to add this functionality, I would be happy if you approve or correct this PR.

Also inside this PR the method get_dn() in client.py is implemented, to be able to gather the distinguished name by samAccountName.

Best regards,
Daniel

